### PR TITLE
UCG: fix configure to include UCG

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -191,9 +191,11 @@ AS_IF([test "x$with_docs_only" = xyes],
      AM_CONDITIONAL([ENABLE_EXPERIMENTAL_API], [false])
      AM_CONDITIONAL([INSTALL_DEVEL_HEADERS], [false])
      AM_CONDITIONAL([HAVE_EXAMPLES], [false])
+     AM_CONDITIONAL([HAVE_UCG], [true]) # docs include UCG headers
     ],
     [
      AM_CONDITIONAL([DOCS_ONLY], [false])
+     AM_CONDITIONAL([HAVE_UCG], [true])
      m4_include([config/m4/compiler.m4])
      m4_include([config/m4/sysdep.m4])
      m4_include([config/m4/ucs.m4])
@@ -322,18 +324,9 @@ AS_IF([test "x$with_docs_only" = xyes],
     AM_CONDITIONAL([HAVE_EXAMPLES], [test "x$enable_examples" = "xyes"])
 
      #
-     # Disable UCG - Group collective operations component
+     # UCG - Group collective operations component (Always enabled in this version)
      #
-     AC_ARG_ENABLE([ucg],
-                   [AS_HELP_STRING([--disable-ucg],
-                                   [Disable the group collective operations component, default: NO])],
-         [AM_CONDITIONAL([HAVE_UCG], [false])
-          AC_DEFINE(   [ENABLE_UCG], [0])],
-         [AS_IF([test "x$enable_ucg" != "xno"],
-                [AM_CONDITIONAL([HAVE_UCG], [true])
-                 AC_DEFINE(   [ENABLE_UCG], [1],
-                     [Enable Groups and collective operations support (UCG)])])])
-
+     AC_DEFINE([ENABLE_UCG], [1], [Enable Groups and collective operations support (UCG)])
     ]) # Docs only
 
 #
@@ -411,7 +404,5 @@ AC_MSG_NOTICE([      ROCM modules:   <$(echo $uct_rocm_modules|tr ':' ' ') >])
 AC_MSG_NOTICE([        IB modules:   <$(echo $uct_ib_modules|tr ':' ' ') >])
 AC_MSG_NOTICE([       UCM modules:   <$(echo $ucm_modules|tr ':' ' ') >])
 AC_MSG_NOTICE([      Perf modules:   <$(echo $ucx_perftest_modules|tr ':' ' ') >])
-AS_IF([test "x$enable_ucg" != "xno"],
-      [AC_MSG_NOTICE([      UCG modules:    <$(echo $ucg_modules|tr ':' ' ') >])], [])
-])
+AC_MSG_NOTICE([       UCG modules:   <$(echo $ucg_modules|tr ':' ' ') >])], [])
 AC_MSG_NOTICE([=========================================================])


### PR DESCRIPTION
## What
Fixed UCG build.

## Why ?
Before this fix, running `./autogen.sh --with-ucg && ./configure --enable-ucg && make` would NOT build UCG.

## How ?
UCG is now permanently on as part of the `configure.ac` file.
