### PR TITLE
UT: fix some ucg ut failed testcases

### DIFF
--- a/test/gtest/ucg/test_op.cc
+++ b/test/gtest/ucg/test_op.cc
@@ -223,4 +223,6 @@ TEST_F(ucg_op_test, test_op_trigger) {
     ret = ucg_builtin_op_trigger(op, 0, &request);
     ASSERT_EQ(UCS_INPROGRESS, ret);
     ucg_builtin_component.destroy(group);
+    m_ucg_worker = NULL;
+    m_ucg_context = NULL;
 }

--- a/test/gtest/ucg/test_step.cc
+++ b/test/gtest/ucg/test_step.cc
@@ -346,6 +346,8 @@ TEST_F(ucg_step_test, test_step_execute_bcopy) {
     delete iface;
     step->uct_iface = NULL;
     ASSERT_EQ(UCS_OK, ret);
+    m_ucg_worker = NULL;
+    m_ucg_context = NULL;
 }
 
 TEST_F(ucg_step_test, test_step_execute_zcopy) {
@@ -393,4 +395,6 @@ TEST_F(ucg_step_test, test_step_execute_zcopy) {
     step->uct_iface = NULL;
     ASSERT_EQ(UCS_OK, ret);
     ASSERT_EQ((unsigned)0, step->zcopy.num_store);
+    m_ucg_worker = NULL;
+    m_ucg_context = NULL;
 }


### PR DESCRIPTION
## What
fix ut testcases: test_op_trigger,test_step_execute_bcopy&zcopy

## Why ?
thus 3 testcases occasionally coredump after run over, temply fix them by no cleanup

## How ?
do not cleanup ucp_worker and ucp_context
